### PR TITLE
Data generalization

### DIFF
--- a/R/staggregate.R
+++ b/R/staggregate.R
@@ -230,31 +230,6 @@ polygon_aggregation <- function(clim_dt, weights_dt, list_names, time_agg){
                     day = lubridate::day(date),
                     hour = lubridate::hour(date))] # NOTE: if the timestep is smaller than hourly, the minutes and seconds will not be recorded. However, this does not affect the output since the lowest aggregation level possible is 'hour'.
 
-  # Check that the temporal aggregation is not of higher temporal resolution than the available data
-  # (e.g. that you don't have monthly data being aggregated to daily levels)
-
-  # Determine the granularity of your data
-  if (length(unique(merged_dt$hour)) > 1) {
-    data_granularity <- "hour"
-  } else if (length(unique(merged_dt$day)) > 1) {
-    data_granularity <- "day"
-  } else if (length(unique(merged_dt$month)) > 1) {
-    data_granularity <- "month"
-  } else {
-    data_granularity <- "year"
-  }
-
-  # Define a hierarchy of temporal resolutions
-  temporal_hierarchy <- c("year", "month", "day", "hour")
-
-  # Compare the data granularity with the time_agg value
-  data_granularity_index <- match(data_granularity, temporal_hierarchy)
-  time_agg_index <- match(time_agg, temporal_hierarchy)
-
-  if (time_agg_index > data_granularity_index) {
-    stop(crayon::red(paste("The temporal aggregation level", time_agg, "is of higher resolution than the available data, which is at the", data_granularity, "level. Please ensure that you use data with an appropriate temporal resolution for this level of temporal aggregation.")))
-  }
-
   # Temporal Aggregation
   if(time_agg == "year"){
     message(crayon::green("Aggregating by polygon and year"))

--- a/R/staggregate.R
+++ b/R/staggregate.R
@@ -207,7 +207,6 @@ polygon_aggregation <- function(clim_dt, weights_dt, list_names, time_agg){
 
 
   # Convert layer names to dates
-  message(crayon::yellow("Assuming layer name format which after removal of any non-digit characters from the start is compatible with lubridate::as_datetime()"))
   clim_dt[, date := stringr::str_replace(date, "^[^0-9]+", "")] # Remove any non-digit characters from the start of the string
   clim_dt[, date := lubridate::as_datetime(date)]
 

--- a/R/staggregate.R
+++ b/R/staggregate.R
@@ -167,8 +167,8 @@ polygon_aggregation <- function(clim_dt, weights_dt, list_names, time_agg){
 
 
   # Convert layer names to dates
-  message(crayon::yellow("Assuming layer name format which after removal of the first character is compatible with lubridate::as_datetime()"))
-  clim_dt[, date := stringr::str_sub(date, 2, -1)]
+  message(crayon::yellow("Assuming layer name format which after removal of any non-digit characters from the start is compatible with lubridate::as_datetime()"))
+  clim_dt[, date := stringr::str_replace(date, "^[^0-9]+", "")] # Remove any non-digit characters from the start of the string
   clim_dt[, date := lubridate::as_datetime(date)]
 
   # Keyed merge on the x/y column

--- a/R/staggregate.R
+++ b/R/staggregate.R
@@ -174,6 +174,9 @@ daily_aggregation <- function(data, overlay_weights, daily_agg, time_interval='1
 
 # Function to infer date-times for raster layers based on a time interval
 infer_layer_datetimes <- function(raster_stack, start_date, time_interval) {
+  # Turn the data into a raster stack in case it's a SpatRaster
+  raster_stack <- raster::stack(data)
+
   # Number of layers in the raster stack
   num_layers <- raster::nlayers(raster_stack)
 

--- a/R/staggregate.R
+++ b/R/staggregate.R
@@ -307,8 +307,8 @@ polygon_aggregation <- function(clim_dt, weights_dt, list_names, time_agg){
 #' @param time_interval the time interval between layers in the raster to be
 #'  aggregated. To be input in a format compatible with seq(), e.g.
 #'  `'1 day'` or `'3 months'`. The default is `'1 hour'` and this argument is
-#'  required if daily_agg is not `'none'` or if the layer name format is not
-#'  compatible with stagg.
+#'  required if daily_agg is not `'none'` or if the `start_date` argument is not
+#'  `NA`.
 #' @param degree the highest exponent to raise the data to
 #'
 #' @examples
@@ -319,7 +319,7 @@ polygon_aggregation <- function(clim_dt, weights_dt, list_names, time_agg){
 #'                          # before transformation
 #'   time_agg = "month", # Sum the transformed daily values across months
 #'   start_date = "2020-01-01 00:00:00", # The start date of the supplied data, only required if the layer name format is not compatible with stagg
-#'   time_interval = "1 hour", # The temporal interval of the supplied data, required if daily_agg is not "none" or if the layer name format is not compatible with stagg
+#'   time_interval = "1 hour", # The temporal interval of the supplied data, required if daily_agg is not "none" or if the start_date argument is not NA
 #'   degree = 4 # Highest order
 #'   )
 #'
@@ -428,8 +428,8 @@ staggregate_polynomial <- function(data, overlay_weights, daily_agg, time_agg = 
 #' @param time_interval the time interval between layers in the raster to be
 #'  aggregated. To be input in a format compatible with seq(), e.g.
 #'  `'1 day'` or `'3 months'`. The default is `'1 hour'` and this argument is
-#'  required if daily_agg is not `'none'` or if the layer name format is not
-#'  compatible with stagg.
+#'  required if daily_agg is not `'none'` or if the `start_date` argument is not
+#'  `NA`.
 #' @param knot_locs where to place the knots
 #'
 #' @examples
@@ -440,7 +440,7 @@ staggregate_polynomial <- function(data, overlay_weights, daily_agg, time_agg = 
 #'                        # transformation
 #' time_agg = "month", # Sum the transformed daily values across months
 #' start_date = "2020-01-01 00:00:00", # The start date of the supplied data, only required if the layer name format is not compatible with stagg
-#' time_interval = "1 hour", # The temporal interval of the supplied data, required if daily_agg is not "none" or if the layer name format is not compatible with stagg
+#' time_interval = "1 hour", # The temporal interval of the supplied data, required if daily_agg is not "none" or if the start_date argument is not NA
 #' knot_locs = c(0, 7.5, 12.5, 20) # Where to place knots
 #' )
 #'
@@ -577,8 +577,8 @@ staggregate_spline <- function(data, overlay_weights, daily_agg, time_agg = "mon
 #' @param time_interval the time interval between layers in the raster to be
 #'  aggregated. To be input in a format compatible with seq(), e.g.
 #'  `'1 day'` or `'3 months'`. The default is `'1 hour'` and this argument is
-#'  required if daily_agg is not `'none'` or if the layer name format is not
-#'  compatible with stagg.
+#'  required if daily_agg is not `'none'` or if the `start_date` argument is not
+#'  `NA`.
 #' @param bin_breaks A vector of bin boundaries to split the data by
 #'
 #' @examples
@@ -589,7 +589,7 @@ staggregate_spline <- function(data, overlay_weights, daily_agg, time_agg = "mon
 #'                          # before transformation
 #'   time_agg = "month", # Sum the transformed daily values across months
 #'   start_date = "2020-01-01 00:00:00", # The start date of the supplied data, only required if the layer name format is not compatible with stagg
-#'   time_interval = "1 hour", # The temporal interval of the supplied data, required if daily_agg is not "none" or if the layer name format is not compatible with stagg
+#'   time_interval = "1 hour", # The temporal interval of the supplied data, required if daily_agg is not "none" or if the start_date argument is not NA
 #'   bin_breaks = c(0, 2.5, 5, 7.5, 10) # Draw 6 bins from ninf to 0, 0 to 2.5,
 #'                                      # 2.5 to 5, 5 to 7.5, 7.5 to 10, 10 to inf
 #'   )
@@ -724,7 +724,7 @@ staggregate_bin <- function(data, overlay_weights, daily_agg, time_agg = "month"
 #' @param time_interval the time interval between layers in the raster to be
 #'  aggregated. To be input in a format compatible with seq(), e.g.
 #'  `'1 day'` or `'3 months'`. The default is `'1 hour'` and this argument is
-#'  required if the layer name format is not compatible with stagg.
+#'  required if the `start_date` argument is not `NA`.
 #' @param thresholds A vector of temperature thresholds critical to a crop
 #'
 #' @examples
@@ -733,7 +733,7 @@ staggregate_bin <- function(data, overlay_weights, daily_agg, time_agg = "month"
 #'   overlay_weights = overlay_weights_kansas, # Output from overlay_weights()
 #'   time_agg = "month", # Sum the transformed daily values across months
 #'   start_date = "2020-01-01 00:00:00", # The start date of the supplied data, only required if the layer name format is not compatible with stagg
-#'   time_interval = "1 hour", # The temporal interval of the supplied data, only required if the layer name format is not compatible with stagg
+#'   time_interval = "1 hour", # The temporal interval of the supplied data, only required if the start_date is not NA
 #'   thresholds = c(0, 10, 20) # Calculate degree days above 0, 10, and 20
 #'                             # degrees Celsius
 #'   )

--- a/R/staggregate.R
+++ b/R/staggregate.R
@@ -172,7 +172,7 @@ polygon_aggregation <- function(clim_dt, weights_dt, list_names, time_agg){
   clim_dt[, date := lubridate::as_datetime(date)]
 
   # Keyed merge on the x/y column
-  merged_dt <- clim_dt[weights_dt, allow.cartesian = TRUE] #cols: x, y, date, value cols 1:k, poly_id, w_area, weight (if weights = T)
+  merged_dt <- clim_dt[weights_dt, allow.cartesian = TRUE] # cols: x, y, date, value cols 1:k, poly_id, w_area, weight (if weights = T)
 
   ## Multiply weights x climate value (all 1:k values); aggregate by month and polygon
   ## -----------------------------------------------
@@ -189,7 +189,7 @@ polygon_aggregation <- function(clim_dt, weights_dt, list_names, time_agg){
   merged_dt[, ':=' (year = lubridate::year(date),
                     month = lubridate::month(date),
                     day = lubridate::day(date),
-                    hour = lubridate::hour(date))]
+                    hour = lubridate::hour(date))] # NOTE: if the timestep is smaller than hourly, the minutes and seconds will not be recorded. However, this does not affect the output since the lowest aggregation level possible is 'hour'.
 
   # Temporal Aggregation
   if(time_agg == "year"){

--- a/R/staggregate.R
+++ b/R/staggregate.R
@@ -133,7 +133,7 @@ daily_aggregation <- function(data, overlay_weights, daily_agg, time_interval='1
 
   # Check if the number of timesteps in a day is a whole number
   if(timesteps_per_day != as.integer(timesteps_per_day)) {
-    stop(crayon::red("The number of timesteps in a day is not a whole number. Please change the `time_interval` argument to reflect a dataset wherein all layers correspond to a specific day in order to perform the daily aggregation."))
+    stop(crayon::red("The number of timesteps in a day is not a whole number. Please change the `time_interval` argument to a number of hours that can evenly divide 24 hours."))
   }
 
   # Check that you have a dataset with a number of layers that is divisible by the number of timesteps in a day

--- a/R/staggregate.R
+++ b/R/staggregate.R
@@ -191,6 +191,31 @@ polygon_aggregation <- function(clim_dt, weights_dt, list_names, time_agg){
                     day = lubridate::day(date),
                     hour = lubridate::hour(date))] # NOTE: if the timestep is smaller than hourly, the minutes and seconds will not be recorded. However, this does not affect the output since the lowest aggregation level possible is 'hour'.
 
+  # Check that the temporal aggregation is not of higher temporal resolution than the available data
+  # (e.g. that you don't have monthly data being aggregated to daily levels)
+
+  # Determine the granularity of your data
+  if (length(unique(merged_dt$hour)) > 1) {
+    data_granularity <- "hour"
+  } else if (length(unique(merged_dt$day)) > 1) {
+    data_granularity <- "day"
+  } else if (length(unique(merged_dt$month)) > 1) {
+    data_granularity <- "month"
+  } else {
+    data_granularity <- "year"
+  }
+
+  # Define a hierarchy of temporal resolutions
+  temporal_hierarchy <- c("year", "month", "day", "hour")
+
+  # Compare the data granularity with the time_agg value
+  data_granularity_index <- match(data_granularity, temporal_hierarchy)
+  time_agg_index <- match(time_agg, temporal_hierarchy)
+
+  if (time_agg_index > data_granularity_index) {
+    stop(crayon::red(paste("The temporal aggregation level", time_agg, "is of higher resolution than the available data, which is at the", data_granularity, "level. Please ensure that you use data with an appropriate temporal resolution for this level of temporal aggregation.")))
+  }
+
   # Temporal Aggregation
   if(time_agg == "year"){
     message(crayon::green("Aggregating by polygon and year"))

--- a/README.Rmd
+++ b/README.Rmd
@@ -45,8 +45,8 @@ The `stagg` package currently does not included functions to download climate da
 
 While the package is designed to be used with ERA5 climate data, other types of climate data can be used. For compatibility with `stagg` climate data should be:  
   - a raster or raster stack (netCDF, .tif or other format compatible with `raster::raster()`) 
-  - hourly or daily temporal resolution   
-    - if hourly, number of layers should be a multiple of 24 (i.e., represent whole days)   
+  - daily or sub-daily temporal resolution   
+    - if sub-daily, number of layers should be consistent. By default, hourly timesteps are assumed (i.e. 24 timesteps per day), though  a different number can be specified using the `timesteps_per_day` argument in the `staggregate_*()` functions.  
   - layer names use a character-date-time or character-date format (e.g., x2021.01.01.00.00.00; x2021.01.01)   
 
 ```{r}

--- a/README.Rmd
+++ b/README.Rmd
@@ -46,10 +46,10 @@ The `stagg` package currently does not included functions to download climate da
 While the package is designed to be used with ERA5 climate data, other types of climate data can be used. For compatibility with `stagg` climate data should be:  
   - a raster or raster stack (netCDF, .tif or other format compatible with `raster::raster()`) 
   - at least yearly temporal resolution, since the most coarse temporal aggregation offered by `stagg` is yearly. 
-    - if sub-daily, number of layers per day should be consistent. By default, hourly time steps are assumed (i.e. 24 time steps per day), though  a different number can be specified using the `timesteps_per_day` argument in the `staggregate_*()` functions.  
+    - if sub-daily, number of layers per day should be consistent. By default, hourly time steps are assumed (i.e. 24 time steps per day), though  a different number can be specified using the `time_interval` argument in the `staggregate_*()` functions.  
   - in order for the temporal aggregation to happen properly, `stagg` must have a way of knowing the temporal information associated with the raster stack being aggregated. This can be achieved one of two ways: 
     - the layer names use a character-date-time or character-date format following a string header, or the start date-time and temporal time steps of the raster stack must be specified in `staggregate_*()`. For example, ERA5 uses the format x2021.01.01.00.00.00 or x2021.01.01, and data retrieved using `climateR` uses the format variable_2021-01-01, both of which are compatible with `stagg`. 
-    - specify the start datetime and temporal interval of your data in the `staggregate_*()` functions using the `start_date` and `interval` arguments. 
+    - specify the start datetime and temporal interval of your data in the `staggregate_*()` functions using the `start_date` and `time_interval` arguments. 
 
 ```{r}
 library(stagg)

--- a/README.Rmd
+++ b/README.Rmd
@@ -41,13 +41,15 @@ Below is example code and commentary aimed at demonstrating expected typical usa
 
 **Important**
 
-The `stagg` package currently does not included functions to download climate data. There are many packages that can be used to download climate data. For example, [`climateR`](https://github.com/mikejohnson51/climateR) provides access to climate datasets from over 2000 different data providers. ERA5 climate data can be download through [`ecmwfr`](https://github.com/bluegreen-labs/ecmwfr), which provides an interface to two European Centre for Medium-Range Weather Forecast APIs. The [`KrigR`](https://github.com/ErikKusch/KrigR) package provides a helpful wrapper function for the `ecmwfr` package to enable direct downloading of ERA5 climate data in R. 
+The `stagg` package currently does not included functions to download climate data. There are many packages that can be used to download climate data. For example, [`climateR`](https://github.com/mikejohnson51/climateR) provides access to climate datasets from over 2000 different data providers. ERA5 climate data can be download through [`ecmwfr`](https://github.com/bluegreen-labs/ecmwfr), which provides an interface to two European Centre for Medium-Range Weather Forecast APIs. The [`KrigR`](https://github.com/ErikKusch/KrigR) package provides a helpful wrapper function for the `ecmwfr` package to enable direct downloading of ERA5 climate data in R. ECMWF also provides a general [guide to downloading ERA5 data](https://confluence.ecmwf.int/display/CKB/How+to+download+ERA5). 
 
 While the package is designed to be used with ERA5 climate data, other types of climate data can be used. For compatibility with `stagg` climate data should be:  
   - a raster or raster stack (netCDF, .tif or other format compatible with `raster::raster()`) 
-  - daily or sub-daily temporal resolution   
-    - if sub-daily, number of layers should be consistent. By default, hourly timesteps are assumed (i.e. 24 timesteps per day), though  a different number can be specified using the `timesteps_per_day` argument in the `staggregate_*()` functions.  
-  - layer names use a character-date-time or character-date format following a string header. For example, ERA5 uses the format x2021.01.01.00.00.00 or x2021.01.01, and data retrieved using `climateR` uses the format variable_2021-01-01, both of which are compatible with `stagg`. This allows for `staggregate_*()` to correctly interpret the temporal structure of the date and aggregate to the appropriate year, month, or day intervals.
+  - at least yearly temporal resolution, since the most coarse temporal aggregation offered by `stagg` is yearly. 
+    - if sub-daily, number of layers per day should be consistent. By default, hourly time steps are assumed (i.e. 24 time steps per day), though  a different number can be specified using the `timesteps_per_day` argument in the `staggregate_*()` functions.  
+  - in order for the temporal aggregation to happen properly, `stagg` must have a way of knowing the temporal information associated with the raster stack being aggregated. This can be achieved one of two ways: 
+    - the layer names use a character-date-time or character-date format following a string header, or the start date-time and temporal time steps of the raster stack must be specified in `staggregate_*()`. For example, ERA5 uses the format x2021.01.01.00.00.00 or x2021.01.01, and data retrieved using `climateR` uses the format variable_2021-01-01, both of which are compatible with `stagg`. 
+    - specify the start datetime and temporal interval of your data in the `staggregate_*()` functions using the `start_date` and `interval` arguments. 
 
 ```{r}
 library(stagg)

--- a/README.Rmd
+++ b/README.Rmd
@@ -47,7 +47,7 @@ While the package is designed to be used with ERA5 climate data, other types of 
   - a raster or raster stack (netCDF, .tif or other format compatible with `raster::raster()`) 
   - daily or sub-daily temporal resolution   
     - if sub-daily, number of layers should be consistent. By default, hourly timesteps are assumed (i.e. 24 timesteps per day), though  a different number can be specified using the `timesteps_per_day` argument in the `staggregate_*()` functions.  
-  - layer names use a character-date-time or character-date format (e.g., x2021.01.01.00.00.00; x2021.01.01)   
+  - layer names use a character-date-time or character-date format following a string header. For example, ERA5 uses the format x2021.01.01.00.00.00 or x2021.01.01, and data retrieved using `climateR` uses the format variable_2021-01-01, both of which are compatible with `stagg`. This allows for `staggregate_*()` to correctly interpret the temporal structure of the date and aggregate to the appropriate year, month, or day intervals.
 
 ```{r}
 library(stagg)


### PR DESCRIPTION
Here, I make the stagg package able to be used with data from sources other than ERA5 by:
- Making it functional with any raster with layer names following the format: any non-digit characters followed by a date compatible with lubridate::as_datetime()
- Making it functional for rasters without adequate layer names by adding the optional `start_date` and `time_interval` arguments in staggregate_*()
- Note that if the user wants the daily_agg but the data is not hourly, they MUST supply the `time_interval` argument in staggregate_*() **even if the layer names are compatible with stagg**, otherwise the default of 1 hour will be used. Note that in theory we could fix this in the future if we did the daily agg based on layer names as well instead of based on the number of timesteps in a day which we infer from `time_interval`. I think we didn't do it in this way originally for computational efficiency. 