### PR TITLE
37 weird cell widths

### DIFF
--- a/R/global_variables.R
+++ b/R/global_variables.R
@@ -5,4 +5,4 @@
 globalVariables(c("cell_area_km2", "coverage_fraction", "day", "era5_grid",
                   "hour", "month", "poly_id", "sum_weight", "value", "w_area",
                   "w_sum", "weight", "x", "y", "year", ".", "is_right_xmin",
-                  "is_left_xmax"))
+                  "is_left_xmax", "x_low", "x_high", "y_low", "y_high", "..cols_to_keep"))

--- a/R/staggregate.R
+++ b/R/staggregate.R
@@ -1,5 +1,5 @@
 # Function to convert raster to data.table from https://gist.github.com/etiennebr/9515738
-as.data.table.raster.terra <- function(x, row.names = NULL, optional = FALSE, xy=FALSE, inmem = terra::inMemory(x), ...) {
+as_data_table_terra <- function(x, row.names = NULL, optional = FALSE, xy=FALSE, inmem = terra::inMemory(x), ...) {
   if(inmem) {
     v <- data.table::as.data.table(terra::as.data.frame(x, row.names=row.names, optional=optional, xy=xy, ...))
     coln <- names(x)
@@ -296,6 +296,8 @@ polygon_aggregation <- function(clim_dt, weights_dt, list_names, time_agg, weigh
     weights_dt[, x_high := x + weights_join_tolerance_x]
     weights_dt[, y_low := y - weights_join_tolerance_y]
     weights_dt[, y_high := y + weights_join_tolerance_y]
+
+    #  Remove x and y columns to avoid confusion in join
     weights_dt[, x := NULL]
     weights_dt[, y := NULL]
 
@@ -305,14 +307,14 @@ polygon_aggregation <- function(clim_dt, weights_dt, list_names, time_agg, weigh
     # through eval and parse
     cols_to_keep <- c(
 
-      # Add these in manually (referring to clim_dt$x by "x.x" prevents the
+      # Add x and y in manually (referring to clim_dt$x by "x.x" prevents the
       # column from being overwritten in the nonequi-join below)
       'x.x',
       'x.y',
 
       # Keep all column names except the tolerance columns created above
       setdiff(colnames(clim_dt), c('x', 'y')),
-      setdiff(colnames(weight_dt), c('x_low', 'x_high', 'y_low', 'y_high')))
+      setdiff(colnames(weights_dt), c('x_low', 'x_high', 'y_low', 'y_high')))
 
 
     # Merge based on tolerance columns
@@ -325,7 +327,7 @@ polygon_aggregation <- function(clim_dt, weights_dt, list_names, time_agg, weigh
                                 x <= x_high,
                                 y >= y_low,
                                 y <= y_high)]
-    setnames(merged_dt, c('x.x', 'x.y'), c('x', 'y'))
+    data.table::setnames(merged_dt, c('x.x', 'x.y'), c('x', 'y'))
   }
 
   ## Multiply weights x climate value (all 1:k values); aggregate by month and polygon
@@ -424,6 +426,15 @@ polygon_aggregation <- function(clim_dt, weights_dt, list_names, time_agg, weigh
 #'  `'1 day'` or `'3 months'`. The default is `'1 hour'` and this argument is
 #'  required if daily_agg is not `'none'` or if the `start_date` argument is not
 #'  `NA`.
+#' @param weights_join_tolerance the tolerance to use when joining
+#' overlay_weights with the climate data by the x and y columns. This is useful
+#' when the height/width of your data cells expressed in degrees is a very long
+#' decimal. The default, `0`, performs a keyed equi-join. Anything other than 0
+#' performs a nonequi-join wherein latitudes/longitudes within the specified
+#' tolerance (inclusive) are considered a match. Passing a single number results
+#' in the tolerance being the same for x and y, but you can also pass a vector
+#' of two numbers to have the first specify the x tolerance and second specify
+#' the y tolerance.
 #' @param degree the highest exponent to raise the data to
 #'
 #' @examples
@@ -493,7 +504,7 @@ staggregate_polynomial <- function(data, overlay_weights, daily_agg, time_agg = 
   create_dt <- function(x){
 
     # Should output spatRaster cells x/y with 365 days as column names
-    dt <- as.data.table.raster.terra(r[[x]], xy=TRUE)
+    dt <- as_data_table_terra(r[[x]], xy=TRUE)
 
     # Set column names with months
     new_names <- c('x', 'y', layer_names)
@@ -520,7 +531,13 @@ staggregate_polynomial <- function(data, overlay_weights, daily_agg, time_agg = 
   }
 
   # Aggregate by polygon
-  sum_by_poly <- polygon_aggregation(clim_dt, overlay_weights, list_names, time_agg)
+  sum_by_poly <- polygon_aggregation(
+    clim_dt,
+    overlay_weights,
+    list_names,
+    time_agg,
+    weights_join_tolerance_x = weights_join_tolerance_x,
+    weights_join_tolerance_y = weights_join_tolerance_y)
 
   return(sum_by_poly)
 
@@ -562,6 +579,15 @@ staggregate_polynomial <- function(data, overlay_weights, daily_agg, time_agg = 
 #'  `'1 day'` or `'3 months'`. The default is `'1 hour'` and this argument is
 #'  required if daily_agg is not `'none'` or if the `start_date` argument is not
 #'  `NA`.
+#' @param weights_join_tolerance the tolerance to use when joining
+#' overlay_weights with the climate data by the x and y columns. This is useful
+#' when the height/width of your data cells expressed in degrees is a very long
+#' decimal. The default, `0`, performs a keyed equi-join. Anything other than 0
+#' performs a nonequi-join wherein latitudes/longitudes within the specified
+#' tolerance (inclusive) are considered a match. Passing a single number results
+#' in the tolerance being the same for x and y, but you can also pass a vector
+#' of two numbers to have the first specify the x tolerance and second specify
+#' the y tolerance.
 #' @param knot_locs where to place the knots
 #'
 #' @examples
@@ -584,7 +610,7 @@ staggregate_polynomial <- function(data, overlay_weights, daily_agg, time_agg = 
 #' head(spline_output)
 #'
 #' @export
-staggregate_spline <- function(data, overlay_weights, daily_agg, time_agg = "month", start_date = NA, time_interval = "1 hour", knot_locs){
+staggregate_spline <- function(data, overlay_weights, daily_agg, time_agg = "month", start_date = NA, time_interval = "1 hour", weights_join_tolerance = 0, knot_locs){
 
   # If the start date is supplied, overwrite the raster's layer names to reflect the specified temporal metadata
   if(!is.na(start_date)){
@@ -596,7 +622,19 @@ staggregate_spline <- function(data, overlay_weights, daily_agg, time_agg = "mon
   if(time_agg == "hour" & daily_agg != "none"){
     message(crayon::yellow("Hourly output requested. Automatically setting daily_agg to \'none\'"))
     daily_agg = "none"
-    }
+  }
+
+  # If tolerance supplied is one number, apply to both x and y.
+  # If two numbers, apply first to x and second to y
+  if(length(weights_join_tolerance) == 1){
+    weights_join_tolerance_x <- weights_join_tolerance
+    weights_join_tolerance_y <- weights_join_tolerance
+  } else if(length(weights_join_tolerance == 2)){
+    weights_join_tolerance_x <- weights_join_tolerance[1]
+    weights_join_tolerance_y <- weights_join_tolerance[2]
+  } else{
+    stop(crayon::red("Please provide one digit or a vector of only two digits for weights_join_tolerance."))
+  }
 
   # Aggregated climate data to daily values
   setup_list <- daily_aggregation(data, overlay_weights, daily_agg, time_interval)
@@ -658,7 +696,7 @@ staggregate_spline <- function(data, overlay_weights, daily_agg, time_agg = "mon
   create_dt <- function(x){
 
     # Should output raster cells x/y with 365 days as column names
-    dt <- as.data.table.raster.terra(r[[x]], xy=TRUE)
+    dt <- as_data_table_terra(r[[x]], xy=TRUE)
 
     # Set column names with months
     new_names <- c('x', 'y', layer_names)
@@ -684,7 +722,13 @@ staggregate_spline <- function(data, overlay_weights, daily_agg, time_agg = "mon
 
 
   # Aggregate by polygon
-  sum_by_poly <- polygon_aggregation(clim_dt, overlay_weights, list_names, time_agg)
+  sum_by_poly <- polygon_aggregation(
+    clim_dt,
+    overlay_weights,
+    list_names,
+    time_agg,
+    weights_join_tolerance_x = weights_join_tolerance_x,
+    weights_join_tolerance_y = weights_join_tolerance_y)
 
   return(sum_by_poly)
 }
@@ -716,6 +760,15 @@ staggregate_spline <- function(data, overlay_weights, daily_agg, time_agg = "mon
 #'  `'1 day'` or `'3 months'`. The default is `'1 hour'` and this argument is
 #'  required if daily_agg is not `'none'` or if the `start_date` argument is not
 #'  `NA`.
+#' @param weights_join_tolerance the tolerance to use when joining
+#' overlay_weights with the climate data by the x and y columns. This is useful
+#' when the height/width of your data cells expressed in degrees is a very long
+#' decimal. The default, `0`, performs a keyed equi-join. Anything other than 0
+#' performs a nonequi-join wherein latitudes/longitudes within the specified
+#' tolerance (inclusive) are considered a match. Passing a single number results
+#' in the tolerance being the same for x and y, but you can also pass a vector
+#' of two numbers to have the first specify the x tolerance and second specify
+#' the y tolerance.
 #' @param bin_breaks A vector of bin boundaries to split the data by
 #'
 #' @examples
@@ -740,7 +793,7 @@ staggregate_spline <- function(data, overlay_weights, daily_agg, time_agg = "mon
 #' head(bin_output)
 #'
 #' @export
-staggregate_bin <- function(data, overlay_weights, daily_agg, time_agg = "month", start_date = NA, time_interval = '1 hour', bin_breaks){
+staggregate_bin <- function(data, overlay_weights, daily_agg, time_agg = "month", start_date = NA, time_interval = '1 hour', weights_join_tolerance = 0, bin_breaks){
 
   # If the start date is supplied, overwrite the raster's layer names to reflect the specified temporal metadata
   if(!is.na(start_date)){
@@ -752,6 +805,19 @@ staggregate_bin <- function(data, overlay_weights, daily_agg, time_agg = "month"
   if(time_agg == "hour" & daily_agg != "none"){
     message(crayon::yellow("Hourly output requested. Automatically setting daily_agg to \'none\'"))
     daily_agg = "none"
+  }
+
+
+  # If tolerance supplied is one number, apply to both x and y.
+  # If two numbers, apply first to x and second to y
+  if(length(weights_join_tolerance) == 1){
+    weights_join_tolerance_x <- weights_join_tolerance
+    weights_join_tolerance_y <- weights_join_tolerance
+  } else if(length(weights_join_tolerance == 2)){
+    weights_join_tolerance_x <- weights_join_tolerance[1]
+    weights_join_tolerance_y <- weights_join_tolerance[2]
+  } else{
+    stop(crayon::red("Please provide one digit or a vector of only two digits for weights_join_tolerance."))
   }
 
   # Aggregate climate data to daily values
@@ -810,7 +876,7 @@ staggregate_bin <- function(data, overlay_weights, daily_agg, time_agg = "month"
   create_dt <- function(x){
 
     # Should output raster cells x/y with 365 days as column names
-    dt <- as.data.table.raster.terra(r[[x]], xy=TRUE)
+    dt <- as_data_table_terra(r[[x]], xy=TRUE)
 
     # Set column names with months
     new_names <- c('x', 'y', layer_names)
@@ -837,7 +903,13 @@ staggregate_bin <- function(data, overlay_weights, daily_agg, time_agg = "month"
 
 
   # Aggregate by polygon
-  sum_by_poly <- polygon_aggregation(clim_dt, overlay_weights, list_names, time_agg)
+  sum_by_poly <- polygon_aggregation(
+    clim_dt,
+    overlay_weights,
+    list_names,
+    time_agg,
+    weights_join_tolerance_x = weights_join_tolerance_x,
+    weights_join_tolerance_y = weights_join_tolerance_y)
 
   return(sum_by_poly)
 }
@@ -868,6 +940,15 @@ staggregate_bin <- function(data, overlay_weights, daily_agg, time_agg = "month"
 #'  aggregated. To be input in a format compatible with seq(), e.g.
 #'  `'1 day'` or `'3 months'`. The default is `'1 hour'` and this argument is
 #'  required if the `start_date` argument is not `NA`.
+#' @param weights_join_tolerance the tolerance to use when joining
+#' overlay_weights with the climate data by the x and y columns. This is useful
+#' when the height/width of your data cells expressed in degrees is a very long
+#' decimal. The default, `0`, performs a keyed equi-join. Anything other than 0
+#' performs a nonequi-join wherein latitudes/longitudes within the specified
+#' tolerance (inclusive) are considered a match. Passing a single number results
+#' in the tolerance being the same for x and y, but you can also pass a vector
+#' of two numbers to have the first specify the x tolerance and second specify
+#' the y tolerance.
 #' @param thresholds A vector of temperature thresholds critical to a crop
 #'
 #' @examples
@@ -888,12 +969,24 @@ staggregate_bin <- function(data, overlay_weights, daily_agg, time_agg = "month"
 #' head(degree_days_output)
 #'
 #' @export
-staggregate_degree_days <- function(data, overlay_weights, time_agg = "month", start_date = NA, time_interval = '1 hour', thresholds){
+staggregate_degree_days <- function(data, overlay_weights, time_agg = "month", start_date = NA, time_interval = '1 hour', weights_join_tolerance = 0, thresholds){
 
   # If the start date is supplied, overwrite the raster's layer names to reflect the specified temporal metadata
   if(!is.na(start_date)){
     message(crayon::green(sprintf("Rewriting the data's temporal metadata (layer names) to reflect a dataset starting on the supplied start date and with a temporal interval of %s", time_interval)))
     data <- infer_layer_datetimes(data, start_date, time_interval)
+  }
+
+  # If tolerance supplied is one number, apply to both x and y.
+  # If two numbers, apply first to x and second to y
+  if(length(weights_join_tolerance) == 1){
+    weights_join_tolerance_x <- weights_join_tolerance
+    weights_join_tolerance_y <- weights_join_tolerance
+  } else if(length(weights_join_tolerance == 2)){
+    weights_join_tolerance_x <- weights_join_tolerance[1]
+    weights_join_tolerance_y <- weights_join_tolerance[2]
+  } else{
+    stop(crayon::red("Please provide one digit or a vector of only two digits for weights_join_tolerance."))
   }
 
   # Run climate data through daily_aggregation)() (not actually aggregating to daily values)
@@ -957,7 +1050,7 @@ staggregate_degree_days <- function(data, overlay_weights, time_agg = "month", s
   create_dt <- function(x){
 
     # Should output raster cells x/y with 365 days as column names
-    dt <- as.data.table.raster.terra(r[[x]], xy=TRUE)
+    dt <- as_data_table_terra(r[[x]], xy=TRUE)
 
     # Set column names with months
     new_names <- c('x', 'y', layer_names)
@@ -986,7 +1079,13 @@ staggregate_degree_days <- function(data, overlay_weights, time_agg = "month", s
 
 
   # Aggregate by polygon
-  sum_by_poly <- polygon_aggregation(clim_dt, overlay_weights, list_names, time_agg)
+  sum_by_poly <- polygon_aggregation(
+    clim_dt,
+    overlay_weights,
+    list_names,
+    time_agg,
+    weights_join_tolerance_x = weights_join_tolerance_x,
+    weights_join_tolerance_y = weights_join_tolerance_y)
 
   return(sum_by_poly)
 

--- a/R/staggregate.R
+++ b/R/staggregate.R
@@ -291,15 +291,20 @@ polygon_aggregation <- function(clim_dt, weights_dt, list_names, time_agg, weigh
 
   } else{
 
+    # Create a copy of the weights data table so we don't change the user's data
+    # without their knowledge. (data.table creates "shallow copies" unless
+    # explicitly told to do otherwise).
+    copied_weights_dt <- data.table::copy(weights_dt)
+
     # Since data.table doesn't allow arithmatic in nonequi-joins, create tolerance columns now
-    weights_dt[, x_low := x - weights_join_tolerance_x]
-    weights_dt[, x_high := x + weights_join_tolerance_x]
-    weights_dt[, y_low := y - weights_join_tolerance_y]
-    weights_dt[, y_high := y + weights_join_tolerance_y]
+    copied_weights_dt[, x_low := x - weights_join_tolerance_x]
+    copied_weights_dt[, x_high := x + weights_join_tolerance_x]
+    copied_weights_dt[, y_low := y - weights_join_tolerance_y]
+    copied_weights_dt[, y_high := y + weights_join_tolerance_y]
 
     #  Remove x and y columns to avoid confusion in join
-    weights_dt[, x := NULL]
-    weights_dt[, y := NULL]
+    copied_weights_dt[, x := NULL]
+    copied_weights_dt[, y := NULL]
 
 
     # Determine which columns to keep in join,
@@ -314,11 +319,11 @@ polygon_aggregation <- function(clim_dt, weights_dt, list_names, time_agg, weigh
 
       # Keep all column names except the tolerance columns created above
       setdiff(colnames(clim_dt), c('x', 'y')),
-      setdiff(colnames(weights_dt), c('x_low', 'x_high', 'y_low', 'y_high')))
+      setdiff(colnames(copied_weights_dt), c('x_low', 'x_high', 'y_low', 'y_high')))
 
 
     # Merge based on tolerance columns
-    merged_dt <- clim_dt[weights_dt, # Right join
+    merged_dt <- clim_dt[copied_weights_dt, # Right join
                          allow.cartesian = TRUE,
 
                          # Specify which columns to keep

--- a/man/staggregate_bin.Rd
+++ b/man/staggregate_bin.Rd
@@ -11,6 +11,7 @@ staggregate_bin(
   time_agg = "month",
   start_date = NA,
   time_interval = "1 hour",
+  weights_join_tolerance = 0,
   bin_breaks
 )
 }
@@ -39,6 +40,16 @@ aggregated. To be input in a format compatible with seq(), e.g.
 \code{'1 day'} or \code{'3 months'}. The default is \code{'1 hour'} and this argument is
 required if daily_agg is not \code{'none'} or if the \code{start_date} argument is not
 \code{NA}.}
+
+\item{weights_join_tolerance}{the tolerance to use when joining
+overlay_weights with the climate data by the x and y columns. This is useful
+when the height/width of your data cells expressed in degrees is a very long
+decimal. The default, \code{0}, performs a keyed equi-join. Anything other than 0
+performs a nonequi-join wherein latitudes/longitudes within the specified
+tolerance (inclusive) are considered a match. Passing a single number results
+in the tolerance being the same for x and y, but you can also pass a vector
+of two numbers to have the first specify the x tolerance and second specify
+the y tolerance.}
 
 \item{bin_breaks}{A vector of bin boundaries to split the data by}
 }

--- a/man/staggregate_degree_days.Rd
+++ b/man/staggregate_degree_days.Rd
@@ -10,6 +10,7 @@ staggregate_degree_days(
   time_agg = "month",
   start_date = NA,
   time_interval = "1 hour",
+  weights_join_tolerance = 0,
   thresholds
 )
 }
@@ -32,6 +33,16 @@ information in the layer names and they do not need to be manually supplied.}
 aggregated. To be input in a format compatible with seq(), e.g.
 \code{'1 day'} or \code{'3 months'}. The default is \code{'1 hour'} and this argument is
 required if the \code{start_date} argument is not \code{NA}.}
+
+\item{weights_join_tolerance}{the tolerance to use when joining
+overlay_weights with the climate data by the x and y columns. This is useful
+when the height/width of your data cells expressed in degrees is a very long
+decimal. The default, \code{0}, performs a keyed equi-join. Anything other than 0
+performs a nonequi-join wherein latitudes/longitudes within the specified
+tolerance (inclusive) are considered a match. Passing a single number results
+in the tolerance being the same for x and y, but you can also pass a vector
+of two numbers to have the first specify the x tolerance and second specify
+the y tolerance.}
 
 \item{thresholds}{A vector of temperature thresholds critical to a crop}
 }

--- a/man/staggregate_polynomial.Rd
+++ b/man/staggregate_polynomial.Rd
@@ -11,6 +11,7 @@ staggregate_polynomial(
   time_agg = "month",
   start_date = NA,
   time_interval = "1 hour",
+  weights_join_tolerance = 0,
   degree
 )
 }
@@ -39,6 +40,16 @@ aggregated. To be input in a format compatible with seq(), e.g.
 \code{'1 day'} or \code{'3 months'}. The default is \code{'1 hour'} and this argument is
 required if daily_agg is not \code{'none'} or if the \code{start_date} argument is not
 \code{NA}.}
+
+\item{weights_join_tolerance}{the tolerance to use when joining
+overlay_weights with the climate data by the x and y columns. This is useful
+when the height/width of your data cells expressed in degrees is a very long
+decimal. The default, \code{0}, performs a keyed equi-join. Anything other than 0
+performs a nonequi-join wherein latitudes/longitudes within the specified
+tolerance (inclusive) are considered a match. Passing a single number results
+in the tolerance being the same for x and y, but you can also pass a vector
+of two numbers to have the first specify the x tolerance and second specify
+the y tolerance.}
 
 \item{degree}{the highest exponent to raise the data to}
 }

--- a/man/staggregate_spline.Rd
+++ b/man/staggregate_spline.Rd
@@ -11,6 +11,7 @@ staggregate_spline(
   time_agg = "month",
   start_date = NA,
   time_interval = "1 hour",
+  weights_join_tolerance = 0,
   knot_locs
 )
 }
@@ -39,6 +40,16 @@ aggregated. To be input in a format compatible with seq(), e.g.
 \code{'1 day'} or \code{'3 months'}. The default is \code{'1 hour'} and this argument is
 required if daily_agg is not \code{'none'} or if the \code{start_date} argument is not
 \code{NA}.}
+
+\item{weights_join_tolerance}{the tolerance to use when joining
+overlay_weights with the climate data by the x and y columns. This is useful
+when the height/width of your data cells expressed in degrees is a very long
+decimal. The default, \code{0}, performs a keyed equi-join. Anything other than 0
+performs a nonequi-join wherein latitudes/longitudes within the specified
+tolerance (inclusive) are considered a match. Passing a single number results
+in the tolerance being the same for x and y, but you can also pass a vector
+of two numbers to have the first specify the x tolerance and second specify
+the y tolerance.}
 
 \item{knot_locs}{where to place the knots}
 }

--- a/tests/testthat/test-staggregate.R
+++ b/tests/testthat/test-staggregate.R
@@ -3,7 +3,7 @@
 testthat::test_that(
   "as.data.table.terra has correct output type, class, and column names",
   {
-    output <- as.data.table.raster.terra(temp_nj_jun_2024_era5[[1]], xy = TRUE)
+    output <- as_data_table_terra(temp_nj_jun_2024_era5[[1]], xy = TRUE)
 
     expect_type(output, "list")
     expect_is(output, "data.table")
@@ -48,7 +48,7 @@ testthat::test_that(
   "polygon_aggregation has correct output type, class, and column names",
   {
     # Make clim_dt input for polygon_aggregation() (the numbers are nonsensical)
-    clim_dt_input <- as.data.table.raster.terra(temp_nj_jun_2024_era5, xy = TRUE) %>%
+    clim_dt_input <- as_data_table_terra(temp_nj_jun_2024_era5, xy = TRUE) %>%
       dplyr::select(c(1,2, 4:10)) %>%
       tidyr::pivot_longer(cols = 3:9, names_to = "date", values_to = "order_1") %>%
       dplyr::mutate(x = x + 360) %>%
@@ -57,7 +57,9 @@ testthat::test_that(
     output <- polygon_aggregation(clim_dt_input,
                                   overlay_weights_nj,
                                   c("order_1"),
-                                  "hour")
+                                  "hour",
+                                  weights_join_tolerance_x = 0,
+                                  weights_join_tolerance_y = 0)
 
     expect_type(output, "list")
     expect_is(output, "data.frame")


### PR DESCRIPTION
Implementing a user-defined tolerance for joining the overlay_weights with the climate table. Note that when a tolerance is not implemented, the regular join is used because (I assume) it's faster / less memory intensive.